### PR TITLE
Update gpg-error to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cfg-if = "0.1"
 libc = "0.2"
 bitflags = "0.9"
 lazy_static = "0.2"
-gpg-error = "0.2"
+gpg-error = "0.3"
 
 [dependencies.libgcrypt-sys]
 path = "libgcrypt-sys"

--- a/libgcrypt-sys/Cargo.toml
+++ b/libgcrypt-sys/Cargo.toml
@@ -33,4 +33,4 @@ gcc = "0.3"
 
 [dependencies]
 libc = "0.2"
-libgpg-error-sys = "0.2"
+libgpg-error-sys = "0.3"

--- a/libgcrypt-sys/build.rs
+++ b/libgcrypt-sys/build.rs
@@ -103,7 +103,7 @@ fn try_build() -> bool {
     let build = dst.clone().join("build");
     let target = env::var("TARGET").unwrap();
     let host = env::var("HOST").unwrap();
-    let gpgerror_root = env::var("DEP_GPG_ERROR_ROOT").unwrap();
+    let gpgerror_root = env::var("DEP_GPG_ERROR_GEN").unwrap();
     let compiler = gcc::Build::new().get_compiler();
     let cflags = compiler.args().iter().fold(OsString::new(), |mut c, a| {
         c.push(a);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ extern crate core;
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
-extern crate libgcrypt_sys as ffi;
+pub extern crate libgcrypt_sys as ffi;
 #[macro_use]
 pub extern crate gpg_error as error;
 

--- a/src/mpi/integer.rs
+++ b/src/mpi/integer.rs
@@ -6,10 +6,10 @@ use std::ptr;
 use std::str;
 
 use ffi;
+use ffi::errors;
 use libc::c_uint;
 
 use {Error, NonZero, Result};
-use error;
 use buffer::Buffer;
 use rand::Level;
 
@@ -90,7 +90,7 @@ impl Integer {
             } else if bytes.contains(&0) {
                 0
             } else {
-                return Err(Error::from_code(error::GPG_ERR_INV_ARG));
+                return Err(Error::from_code(errors::GPG_ERR_INV_ARG));
             };
             return_err!(ffi::gcry_mpi_scan(
                 &mut raw,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,7 +1,8 @@
 extern crate gcrypt;
 
 use gcrypt::Token;
-use gcrypt::error::{self, ErrorCode};
+use gcrypt::error::{ErrorCode};
+use gcrypt::ffi::errors;
 use gcrypt::cipher::{self, Algorithm as CipherAlgorithm, Cipher, Mode as CipherMode};
 use gcrypt::digest::{self, Algorithm as DigestAlgorithm, MessageDigest};
 use gcrypt::kdf;
@@ -2027,7 +2028,7 @@ fn verify_signature(
         pkey::verify(pkey, bad_hash, sig)
             .err()
             .map_or(0, |e| e.code()),
-        error::GPG_ERR_BAD_SIGNATURE
+        errors::GPG_ERR_BAD_SIGNATURE
     );
 }
 
@@ -2043,7 +2044,7 @@ fn check_pkey_sign(algo: KeyAlgorithm, skey: &SExpression, pkey: &SExpression) {
             b"(data\n (flags oaep)\n\
             (hash sha1 #11223344556677889900AABBCCDDEEFF10203040#))\n",
             None,
-            error::GPG_ERR_CONFLICT,
+            errors::GPG_ERR_CONFLICT,
         ),
         (
             b"(data\n (flags pkcs1)\n\
@@ -2056,13 +2057,13 @@ fn check_pkey_sign(algo: KeyAlgorithm, skey: &SExpression, pkey: &SExpression) {
             b"(data\n (flags )\n\
             (hash sha1 #11223344556677889900AABBCCDDEEFF10203040#))\n",
             None,
-            error::GPG_ERR_CONFLICT,
+            errors::GPG_ERR_CONFLICT,
         ),
         (
             b"(data\n (flags pkcs1)\n\
             (hash foo #11223344556677889900AABBCCDDEEFF10203040#))\n",
             Some(KeyAlgorithm::Rsa),
-            error::GPG_ERR_DIGEST_ALGO,
+            errors::GPG_ERR_DIGEST_ALGO,
         ),
         (
             b"(data\n (flags )\n (value #11223344556677889900AA#))\n",
@@ -2082,12 +2083,12 @@ fn check_pkey_sign(algo: KeyAlgorithm, skey: &SExpression, pkey: &SExpression) {
         (
             b"(data\n (flags pkcs1)\n (value #11223344556677889900AA#))\n",
             Some(KeyAlgorithm::Rsa),
-            error::GPG_ERR_CONFLICT,
+            errors::GPG_ERR_CONFLICT,
         ),
         (
             b"(data\n (flags raw foo)\n (value #11223344556677889900AA#))\n",
             None,
-            error::GPG_ERR_INV_FLAG,
+            errors::GPG_ERR_INV_FLAG,
         ),
         (
             b"(data\n (flags pss)\n\
@@ -2305,7 +2306,7 @@ fn check_pkey_crypt(algo: pkey::Algorithm, skey: &SExpression, pkey: &SExpressio
             (hash sha1 #11223344556677889900AABBCCDDEEFF10203040#))\n",
             b"",
             false,
-            error::GPG_ERR_CONFLICT,
+            errors::GPG_ERR_CONFLICT,
             0,
             false,
         ),
@@ -2315,7 +2316,7 @@ fn check_pkey_crypt(algo: pkey::Algorithm, skey: &SExpression, pkey: &SExpressio
             (hash sha1 #11223344556677889900AABBCCDDEEFF10203040#))\n",
             b"",
             false,
-            error::GPG_ERR_INV_FLAG,
+            errors::GPG_ERR_INV_FLAG,
             0,
             false,
         ),
@@ -2325,7 +2326,7 @@ fn check_pkey_crypt(algo: pkey::Algorithm, skey: &SExpression, pkey: &SExpressio
             b"(flags oaep)",
             true,
             0,
-            error::GPG_ERR_ENCODING_PROBLEM,
+            errors::GPG_ERR_ENCODING_PROBLEM,
             true,
         ),
         (
@@ -2334,7 +2335,7 @@ fn check_pkey_crypt(algo: pkey::Algorithm, skey: &SExpression, pkey: &SExpressio
             b"(flags pkcs1)",
             true,
             0,
-            error::GPG_ERR_ENCODING_PROBLEM,
+            errors::GPG_ERR_ENCODING_PROBLEM,
             true,
         ),
         (
@@ -2342,7 +2343,7 @@ fn check_pkey_crypt(algo: pkey::Algorithm, skey: &SExpression, pkey: &SExpressio
             b"(data\n (flags pss)\n (value #11223344556677889900AA#))\n",
             b"",
             false,
-            error::GPG_ERR_CONFLICT,
+            errors::GPG_ERR_CONFLICT,
             0,
             false,
         ),


### PR DESCRIPTION
This allows using this library and rust-gpgme (as of v0.7.1) together.